### PR TITLE
ContextMenu improvements

### DIFF
--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -10,6 +10,7 @@ export default function ()
 
     Hooks.on("init", () => 
     {
+        CONFIG.ux.ContextMenu = warhammer.apps.WarhammerContextMenu;
 
         CONFIG.MeasuredTemplate.documentClass.prototype.areaEffect = function () 
         {

--- a/src/sheets/v2/mixin.js
+++ b/src/sheets/v2/mixin.js
@@ -176,13 +176,13 @@ const WarhammerSheetMixinV2 = (cls) => class extends cls
         this._handleContainers();
 
         // Anything in a list row should be right clickable (usually items) unless otherwise specified (nocontext)
-        new WarhammerContextMenu(this.element, ".list-row:not(.nocontext)", this._getContextMenuOptions(), {jQuery: false, fixed: true});
+        this._createContextMenu(this._getContextMenuOptions, ".list-row:not(.nocontext)", {jQuery: false, fixed: true});
 
         // Left clickable context menus (3 vertical pips)
-        new WarhammerContextMenu(this.element, ".context-menu", this._getContextMenuOptions(), {eventName : "click", jQuery: false, fixed: true});
+        this._createContextMenu(this._getContextMenuOptions, ".context-menu", {eventName : "click", jQuery: false, fixed: true});
 
         // Anything else that should be right clickable for context menus
-        new WarhammerContextMenu(this.element, ".context-menu-alt", this._getContextMenuOptions(), {jQuery: false, fixed: true});
+        this._createContextMenu(this._getContextMenuOptions, ".context-menu-alt", {jQuery: false, fixed: true});
     }
 
     _addEventListeners()

--- a/src/util/context-menu.js
+++ b/src/util/context-menu.js
@@ -1,4 +1,4 @@
-export class WarhammerContextMenu extends ContextMenu
+export class WarhammerContextMenu extends foundry.applications.ux.ContextMenu
 {
 
     render(target, options)


### PR DESCRIPTION
### Changes
- Registers `WarhammerContextMenu` as _the_ ContextMenu implementation in `CONFIG.ux.ContextMenu`, so modules (and systems) are automatically using it
- DocumentMixin creates ContextMenu using `this._createContextMenu`, which requires less arguments, is open for extension by modules (or systems) and potentially allows dynamically changing ContextMenuOptions on subsequent re-renders (no idea if that would be every used, can't think of use case)
- Uses full namespace (fixes v13 warning and future-proofs for v15)