### PR TITLE
fix: Fix value dialog select always using keys

### DIFF
--- a/src/apps/value-dialog.js
+++ b/src/apps/value-dialog.js
@@ -100,7 +100,7 @@ export default class ValueDialog extends HandlebarsApplicationMixin(ApplicationV
 
             context.values = Object.keys(this.values).map(v => 
             {
-                return {key : v, display : this.values[v] == "string" ? this.values[v] : v};
+                return {key : v, display : typeof this.values[v] == "string" ? this.values[v] : v};
             });
         }
 

--- a/static/templates/apps/dialog/value-dialog.hbs
+++ b/static/templates/apps/dialog/value-dialog.hbs
@@ -5,7 +5,7 @@
       {{#if values}}
         <select name="value">
           <option value=""></option>
-          {{selectOptions values nameAttr="key" labelAttr="display" selected=defaultValue}}
+          {{selectOptions values valueAttr="key" labelAttr="display" selected=defaultValue}}
         </select>
       {{else}}
         <input name="value" type="text" value="{{defaultValue}}" autofocus=true>


### PR DESCRIPTION
Fix of when using ValueDialog to display select it always uses keys of object during render.
Refactor of nameAttr into valueAttr since the former is deprecated.